### PR TITLE
feat: disable text select in track list

### DIFF
--- a/src/ui/track_list.rs
+++ b/src/ui/track_list.rs
@@ -87,7 +87,9 @@ impl egui::Widget for TrackList<'_> {
                         ui.strong("Artist");
                     });
                 })
-                .body(|body| {
+                .body(|mut body| {
+                    body.ui_mut().style_mut().interaction.selectable_labels = false;
+
                     let tracks = self
                         .tracks
                         .iter()


### PR DESCRIPTION
Disable text select in track list so that it does not get in the way when double click to play.